### PR TITLE
(fix): Allow the use of parens as a non-confusing arrow syntax.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     'arrow-parens': ['error','as-needed', {
       'requireForBlockBody': true
     }],
-    'no-confusing-arrow': 'error',
+    'no-confusing-arrow': ['error', { 'allowParens': true }],
     'no-duplicate-imports': 'error',
     'import/named': 'error',
     'import/default': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seedrs/eslint-config-seedrs-base",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Seedr's ESLint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Allow the use of parentheses as a non confusing arrow function syntax.

e.g.
```js
//Incorrect
(a) => a ? true : false

//Correct
(a) => (a ? true : false);
```