### PR TITLE
feat(index.js): Increase max-len rule to 150 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = {
     'eol-last': ['error','always'],
     'array-bracket-spacing': ['error','never'],
     'object-curly-spacing': ['error','always'],
-    'max-len': ['error',100],
+    'max-len': ['error',150],
     'comma-style': ['error','last'],
     'comma-dangle': ['error','never'],
     'semi': 'error',


### PR DESCRIPTION
## Reason for the change

We were constantly coming up against this when doing string interpolation and some simple one liner
arrow functions so it was decided to increase the max-len to 150.