### PR TITLE
fix(package.json): Update the compatible versions of eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/seedrs/eslint-config-seedrs-base#readme",
   "peerDependencies": {
-    "eslint": ">= 4.12.1 <= 5.3.0",
+    "eslint": ">= 4.12.1 <= 5.6.0",
     "eslint-plugin-import": "^2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What does it do?

When using versions of eslint > 5.3.0 a warning message was appearing when installing this package. This has now been updated to include 5.6.0 to squash the warnings.